### PR TITLE
Rebrand to FTorch-benchmarks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(fortran-pytorch-lib-benchmark Fortran)
+project(FTorch-benchmark Fortran)
 
 # Set a custom build type called Profile that is based on RelWithDebInfo
 # and populate it with flags to use instrumented profiling (gprof).

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ This repository contains code to investigate that surprising result.
 ## Requirements
 Follow the build instructions below to set up the following requirements:
 
-1) [Fortran-PyTorch-lib](https://github.com/Cambridge-ICCS/fortran-pytorch-lib) repository.
+1) [FTorch](https://github.com/Cambridge-ICCS/FTorch) repository.
 2) CMake >= 3.14
 3) Python
 4) a virtual environment with PyTorch and NumPy installed
 
 ## Build instructions
-Get the [fortran-PyTorch-lib](https://github.com/Cambridge-ICCS/fortran-pytorch-lib) repository if you haven't already got it. Follow the installation instructions on the ReadMe of that repository. 
+Install the [FTorch](https://github.com/Cambridge-ICCS/FTorch) library if you haven't already got it. Follow the installation instructions on the README of that repository. 
 
-In your fortran-pytorch-lib-benchmark repository, create a build directory and run `cmake` as follows, noting the cmake options below:
+In your FTorch-benchmark repository, create a build directory and run `cmake` as follows, noting the cmake options below:
 
 ```
 mkdir build
@@ -25,7 +25,7 @@ cmake ..
 ```
 You may need to specify the path to PyTorch with the option `-DCMAKE_PREFIX-PATH=<full-path-to-PyTorch>`. 
 
-You may also need to specify the path to the CMake library files by using the option `-DFTorch_DIR=<full-path-to-cmake-lib-files>/lib/cmake/`. This is the location you specified when installing fortran-pytorch-lib, if you used `-DCMAKE_INSTALL_PREFIX`. The default location is /usr/local. 
+You may also need to specify the path to the CMake library files by using the option `-DFTorch_DIR=<full-path-to-cmake-lib-files>/lib/cmake/`. This is the location you specified when installing FTorch, if you used `-DCMAKE_INSTALL_PREFIX`. The default location is /usr/local. 
 
 You can specify `cmake` options like `-DCMAKE_BUILD_TYPE=RelWithDebInfo`
 or `-DCMAKE_Fortran_COMPILER=ifort` if you need.


### PR DESCRIPTION
Closes #19 

Rebranding to FTorch-benchmark
- [x] Update references in Main README and CMakeLists
- [x] Check for any other references to fortran-pytorch-lib-benchmark
- [ ] We could restructure the code into separate folders?
- [x] Rename repo on github