### PR TITLE
Fix cmake python finder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,8 @@ target_link_libraries(benchmarker_cgdrag_torch PRIVATE FTorch::ftorch )
 target_sources(benchmarker_cgdrag_torch PRIVATE benchmarker_utils.f90)
 
 # Make sure python present
-find_package(Python REQUIRED COMPONENTS Development)
+set(Python_FIND_STRATEGY LOCATION)
+find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
 
 # Benchmarking Forpy

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,9 @@ target_link_libraries(benchmarker_cgdrag_torch PRIVATE FTorch::ftorch )
 target_sources(benchmarker_cgdrag_torch PRIVATE benchmarker_utils.f90)
 
 # Make sure python present
+# Search until Python version satisfying constraints is located
 set(Python_FIND_STRATEGY LOCATION)
+# Load interpreter and matching directories/libraries
 find_package(Python REQUIRED COMPONENTS Interpreter Development)
 
 


### PR DESCRIPTION
Resolves #21

From testing locally, both changes seem to be necessary in order to ensure the correct Python version to be used when multiple options are available.

Note: as of cmake 3.15, there is also a `Python_FIND_VIRTUALENV` variable, but this doesn't seem to resolve the issue.

To do:

- [x] Test in another environment (e.g. CSD3)