### PR TITLE
WIP: Like-for-like comparison with SimpleNet case

### DIFF
--- a/compare_simplenet/.gitignore
+++ b/compare_simplenet/.gitignore
@@ -1,0 +1,1 @@
+smartsim_experiment/

--- a/compare_simplenet/CMakeLists.txt
+++ b/compare_simplenet/CMakeLists.txt
@@ -1,0 +1,35 @@
+project(simplenet_fortran_smartsim)
+
+cmake_minimum_required(VERSION 3.13)
+enable_language(Fortran)
+SET(CMAKE_FC_COMPILER gfortran)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_C_STANDARD 99)
+
+if(NOT DEFINED SMARTREDIS_INSTALL_PATH)
+  set(SMARTREDIS_INSTALL_PATH "/home/joe/software/tools/smartredis/install")
+endif()
+
+# Specify all pre-processor and library dependencies
+find_library(SMARTREDIS_LIBRARY smartredis PATHS ${SMARTREDIS_INSTALL_PATH}/lib NO_DEFAULT_PATH REQUIRED)
+find_library(SMARTREDIS_FORTRAN_LIBRARY smartredis-fortran PATHS ${SMARTREDIS_INSTALL_PATH}/lib NO_DEFAULT_PATH REQUIRED)
+# find_library(HIREDIS hiredis PATHS ${SMARTREDIS_INSTALL_PATH}/lib NO_DEFAULT_PATH REQUIRED)
+# find_library(REDISPP redis++ PATHS ${SMARTREDIS_INSTALL_PATH}/lib NO_DEFAULT_PATH REQUIRED)
+set(SMARTREDIS_LIBRARIES
+        ${SMARTREDIS_LIBRARY}
+        ${SMARTREDIS_FORTRAN_LIBRARY}
+        # ${HIREDIS}
+        # ${REDISPP}
+)
+
+include_directories(SYSTEM
+    # /usr/local/include
+    ${SMARTREDIS_INSTALL_PATH}/include
+)
+
+# Build executables
+add_executable(simplenet_fortran_smartsim simplenet_fortran_smartsim.f90)
+target_link_libraries(simplenet_fortran_smartsim ${SMARTREDIS_LIBRARIES})
+
+# TODO: Avoid export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:/home/joe/software/tools/smartredis/install/lib with rpath setting

--- a/compare_simplenet/build.sh
+++ b/compare_simplenet/build.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+source ~/.virtualenvs/smartsim/bin/activate
+
+BUILD_DIR="$(pwd)/build"
+rm -rf "${BUILD_DIR}"
+
+FTORCH_BUILD_DIR="${SOFTWARE}/ftorch/build"
+SMARTREDIS_BUILD_DIR="${SOFTWARE}/tools/smartredis/install"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${FTORCH_BUILD_DIR}/lib"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:${SMARTREDIS_BUILD_DIR}/lib"
+
+cmake -S . -B "${BUILD_DIR}" -DCMAKE_PREFIX_PATH="${FTORCH_BUILD_DIR};${SMARTREDIS_BUILD_DIR}"
+cmake --build "${BUILD_DIR}"

--- a/compare_simplenet/simplenet.py
+++ b/compare_simplenet/simplenet.py
@@ -1,0 +1,1 @@
+/home/joe/projects/ftorch/benchmarks/compare_simplenet/../simplenet_model/simplenet.py

--- a/compare_simplenet/simplenet.py
+++ b/compare_simplenet/simplenet.py
@@ -1,1 +1,58 @@
-/home/joe/projects/ftorch/benchmarks/compare_simplenet/../simplenet_model/simplenet.py
+"""Module defining a simple PyTorch 'Net' for coupling to Fortran."""
+
+import torch
+from torch import nn
+
+
+class SimpleNet(nn.Module):
+    """PyTorch module multiplying an input vector by 2."""
+
+    def __init__(
+        self,
+    ) -> None:
+        """
+        Initialize the SimpleNet model.
+
+        Consists of a single Linear layer with weights predefined to
+        multiply the input by 2.
+        """
+        super().__init__()
+        self._fwd_seq = nn.Sequential(
+            nn.Linear(5, 5, bias=False),
+        )
+        with torch.no_grad():
+            self._fwd_seq[0].weight = nn.Parameter(2.0 * torch.eye(5))
+
+    def forward(self, batch: torch.Tensor) -> torch.Tensor:
+        """
+        Pass ``batch`` through the model.
+
+        Parameters
+        ----------
+        batch : torch.Tensor
+            A mini-batch of input vectors of length 5.
+
+        Returns
+        -------
+        torch.Tensor
+            batch scaled by 2.
+
+        """
+        return self._fwd_seq(batch)
+
+
+if __name__ == "__main__":
+    model = SimpleNet()
+    model.eval()
+
+    input_tensor = torch.Tensor([0.0, 1.0, 2.0, 3.0, 4.0])
+    with torch.no_grad():
+        output_tensor = model(input_tensor)
+
+    print(output_tensor)
+    if not torch.allclose(output_tensor, 2 * input_tensor):
+        result_error = (
+            f"result:\n{output_tensor}\ndoes not match expected value:\n"
+            f"{2 * input_tensor}"
+        )
+        raise ValueError(result_error)

--- a/compare_simplenet/simplenet_fortran_smartsim.f90
+++ b/compare_simplenet/simplenet_fortran_smartsim.f90
@@ -19,15 +19,18 @@ program simplenet_fortran
 
    ! Initialise data
    in_data = [0.0_wp, 1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+   write(*,*) "Input (Fortran):", in_data
 
    ierr = client%initialize(.false.)
    ! if (ierr /= SRNoError) error stop  ! TODO: import SRNoError
    ierr = client%put_tensor("in_data", in_data, shape(in_data))
    ! if (ierr /= SRNoError) error stop  ! TODO: import SRNoError
 
+   ! call sleep(10)
+
    ierr = client%unpack_tensor("out_data", out_data, shape(out_data))
    ! if (ierr /= SRNoError) error stop  ! TODO: import SRNoError
 
-   print *, "Output:", out_data
+   write(*,*) "Output (Fortran):", out_data
 
 end program simplenet_fortran

--- a/compare_simplenet/simplenet_fortran_smartsim.f90
+++ b/compare_simplenet/simplenet_fortran_smartsim.f90
@@ -1,0 +1,33 @@
+program simplenet_fortran
+
+   ! Import precision info from iso
+   use, intrinsic :: iso_fortran_env, only : sp => real32
+
+   use smartredis_client, only : client_type
+
+   implicit none
+
+   ! Set working precision for reals
+   integer, parameter :: wp = sp
+
+   ! Set up Fortran data structures
+   real(wp), dimension(5) :: in_data
+   real(wp), dimension(5) :: out_data
+
+   type(client_type) :: client
+   integer :: ierr
+
+   ! Initialise data
+   in_data = [0.0_wp, 1.0_wp, 2.0_wp, 3.0_wp, 4.0_wp]
+
+   ierr = client%initialize(.false.)
+   ! if (ierr /= SRNoError) error stop  ! TODO: import SRNoError
+   ierr = client%put_tensor("in_data", in_data, shape(in_data))
+   ! if (ierr /= SRNoError) error stop  ! TODO: import SRNoError
+
+   ierr = client%unpack_tensor("out_data", out_data, shape(out_data))
+   ! if (ierr /= SRNoError) error stop  ! TODO: import SRNoError
+
+   print *, "Output:", out_data
+
+end program simplenet_fortran

--- a/compare_simplenet/simplenet_python_smartsim.py
+++ b/compare_simplenet/simplenet_python_smartsim.py
@@ -7,24 +7,17 @@ import torch
 import simplenet
 
 os.environ["SMARTSIM_DB_FILE_PARSE_INTERVAL"] = "5"
-language = "fortran"
-exe = "build/simplenet_fortran_smartsim"
-launcher = "local"
-interface = "lo"
 
-exp = Experiment("smartsim_experiment", launcher=launcher)
-db = exp.create_database(port=6780, interface=interface)
-
+exp = Experiment("smartsim_experiment", launcher="local")
+db = exp.create_database(port=6780, interface="lo")
 exp.generate(db, overwrite=True)
-exp.start(db)
+exp.start(db, block=True, summary=True)
 print(f"Database started at address: {db.get_address()}")
 
-# set simulation parameters we can pass as executable arguments
-exe_args = []
 # create "run settings" for the simulation which define how
 # the simulation will be executed when passed to Experiment.start()
-settings = exp.create_run_settings(exe, exe_args=exe_args)
-settings.set_nodes(1)
+settings = exp.create_run_settings("build/simplenet_fortran_smartsim", exe_args=[])
+# settings.set_nodes(1)
 settings.set_tasks(1)
 
 model = exp.create_model("smartsim_model", run_settings=settings)

--- a/compare_simplenet/simplenet_python_smartsim.py
+++ b/compare_simplenet/simplenet_python_smartsim.py
@@ -1,0 +1,40 @@
+import os
+from smartredis import Client
+from smartsim import Experiment
+
+os.environ["SMARTSIM_DB_FILE_PARSE_INTERVAL"] = "5"
+language = "fortran"
+exe = "build/simplenet_fortran_smartsim"
+launcher = "local"
+interface = "lo"
+
+exp = Experiment("smartsim_experiment", launcher=launcher)
+db = exp.create_database(port=6780, interface=interface)
+
+exp.generate(db, overwrite=True)
+exp.start(db)
+print(f"Database started at address: {db.get_address()}")
+
+# set simulation parameters we can pass as executable arguments
+exe_args = []
+# create "run settings" for the simulation which define how
+# the simulation will be executed when passed to Experiment.start()
+settings = exp.create_run_settings(exe, exe_args=exe_args)
+settings.set_nodes(1)
+settings.set_tasks(1)
+
+model = exp.create_model("smartsim_model", run_settings=settings)
+
+exp.generate(model, overwrite=True)
+exp.start(model, block=True, summary=False)
+
+# Connect a SmartRedis client to retrieve data
+client = Client(address=db.get_address()[0], cluster=False)
+in_data = client.get_tensor("in_data")
+print(f"Input: {in_data}")
+
+# TODO: Actually use PyTorch
+out_data = 2 * in_data
+
+print(f"Output: {out_data}")
+client.put_tensor("out_data", out_data)

--- a/compare_simplenet/simplenet_python_smartsim.py
+++ b/compare_simplenet/simplenet_python_smartsim.py
@@ -1,6 +1,10 @@
 import os
+
 from smartredis import Client
 from smartsim import Experiment
+import torch
+
+import simplenet
 
 os.environ["SMARTSIM_DB_FILE_PARSE_INTERVAL"] = "5"
 language = "fortran"
@@ -30,11 +34,12 @@ exp.start(model, block=True, summary=False)
 
 # Connect a SmartRedis client to retrieve data
 client = Client(address=db.get_address()[0], cluster=False)
-in_data = client.get_tensor("in_data")
-print(f"Input: {in_data}")
+trained_model_dummy_input = torch.from_numpy(client.get_tensor("in_data"))
+print(f"Input (Python): {trained_model_dummy_input}")
 
-# TODO: Actually use PyTorch
-out_data = 2 * in_data
+# Use PyTorch to run the forward method on the SimpleNet model
+trained_model = simplenet.SimpleNet()
+trained_model_dummy_output = trained_model(trained_model_dummy_input)
 
-print(f"Output: {out_data}")
-client.put_tensor("out_data", out_data)
+print(f"Output (Python): {trained_model_dummy_output}")
+client.put_tensor("out_data", trained_model_dummy_output.detach().numpy())

--- a/simplenet_model/pt2ts.py
+++ b/simplenet_model/pt2ts.py
@@ -1,0 +1,196 @@
+"""Load a PyTorch model and convert it to TorchScript."""
+
+import os
+from typing import Optional
+
+# FPTLIB-TODO
+# Add a module import with your model here:
+# This example assumes the model architecture is in an adjacent module `my_ml_model.py`
+import simplenet
+import torch
+
+
+def script_to_torchscript(
+    model: torch.nn.Module, filename: Optional[str] = "scripted_model.pt"
+) -> None:
+    """
+    Save PyTorch model to TorchScript using scripting.
+
+    Parameters
+    ----------
+    model : torch.NN.Module
+        a PyTorch model
+    filename : str
+        name of file to save to
+    """
+    print("Saving model using scripting...", end="")
+    scripted_model = torch.jit.script(model)
+    # print(scripted_model.code)
+    scripted_model.save(filename)
+    print("done.")
+
+
+def trace_to_torchscript(
+    model: torch.nn.Module,
+    dummy_input: torch.Tensor,
+    filename: Optional[str] = "traced_model.pt",
+) -> None:
+    """
+    Save PyTorch model to TorchScript using tracing.
+
+    Parameters
+    ----------
+    model : torch.NN.Module
+        a PyTorch model
+    dummy_input : torch.Tensor
+        appropriate size Tensor to act as input to model
+    filename : str
+        name of file to save to
+    """
+    print("Saving model using tracing...", end="")
+    traced_model = torch.jit.trace(model, dummy_input)
+    frozen_model = torch.jit.freeze(traced_model)
+    ## print(frozen_model.graph)
+    ## print(frozen_model.code)
+    frozen_model.save(filename)
+    print("done.")
+
+
+def load_torchscript(filename: Optional[str] = "saved_model.pt") -> torch.nn.Module:
+    """
+    Load a TorchScript from file.
+
+    Parameters
+    ----------
+    filename : str
+        name of file containing TorchScript model
+    """
+    model = torch.jit.load(filename)
+
+    return model
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    parser.add_argument(
+        "--device_type",
+        help="Device type to run the inference on",
+        type=str,
+        choices=["cpu", "cuda", "xpu", "mps"],
+        default="cpu",
+    )
+    parser.add_argument(
+        "--filepath",
+        help="Path to the file containing the PyTorch model",
+        type=str,
+        default=os.path.dirname(__file__),
+    )
+    parsed_args = parser.parse_args()
+    device_type = parsed_args.device_type
+    filepath = parsed_args.filepath
+
+    # =====================================================
+    # Load model and prepare for saving
+    # =====================================================
+
+    # FPTLIB-TODO
+    # Load a pre-trained PyTorch model
+    # Insert code here to load your model as `trained_model`.
+    # This example assumes my_ml_model has a method `initialize` to load
+    # architecture, weights, and place in inference mode
+    trained_model = simplenet.SimpleNet()
+
+    # Switch off specific layers/parts of the model that behave
+    # differently during training and inference.
+    # This may have been done by the user already, so just make sure here.
+    trained_model.eval()
+
+    # =====================================================
+    # Prepare dummy input and check model runs
+    # =====================================================
+
+    # FPTLIB-TODO
+    # Generate a dummy input Tensor `dummy_input` to the model of appropriate size.
+    # This example assumes one input of size (5)
+    trained_model_dummy_input = torch.ones(5)
+
+    # Transfer the model and inputs to GPU device, if appropriate
+    if device_type != "cpu":
+        device = torch.device(device_type)
+        trained_model = trained_model.to(device)
+        trained_model.eval()
+        trained_model_dummy_input = trained_model_dummy_input.to(device)
+
+    # FPTLIB-TODO
+    # Run model for dummy inputs
+    # If something isn't working This will generate an error
+    trained_model_dummy_outputs = trained_model(
+        trained_model_dummy_input,
+    )
+
+    # =====================================================
+    # Save model
+    # =====================================================
+
+    # FPTLIB-TODO
+    # Set the name of the file you want to save the torchscript model to:
+    saved_ts_filename = f"saved_simplenet_model_{device_type}.pt"
+    # A filepath may also be provided. To do this, pass the filepath as an argument to
+    # this script when it is run from the command line, i.e. `./pt2ts.py path/to/model`.
+
+    # FPTLIB-TODO
+    # Save the PyTorch model using either scripting (recommended if possible) or tracing
+    # -----------
+    # Scripting
+    # -----------
+    script_to_torchscript(trained_model, filename=saved_ts_filename)
+
+    # -----------
+    # Tracing
+    # -----------
+    # trace_to_torchscript(
+    #     trained_model, trained_model_dummy_input, filename=saved_ts_filename
+    # )
+
+    print(f"Saved model to TorchScript in '{saved_ts_filename}'.")
+
+    # =====================================================
+    # Check model saved OK
+    # =====================================================
+
+    # Load torchscript and run model as a test, scaling inputs as above
+    trained_model_dummy_input = 2.0 * trained_model_dummy_input
+    trained_model_testing_outputs = trained_model(
+        trained_model_dummy_input,
+    )
+    ts_model = load_torchscript(filename=saved_ts_filename)
+    ts_model_outputs = ts_model(
+        trained_model_dummy_input,
+    )
+
+    if not isinstance(ts_model_outputs, tuple):
+        ts_model_outputs = (ts_model_outputs,)
+    if not isinstance(trained_model_testing_outputs, tuple):
+        trained_model_testing_outputs = (trained_model_testing_outputs,)
+    for ts_output, output in zip(ts_model_outputs, trained_model_testing_outputs):
+        if torch.all(ts_output.eq(output)):
+            print("Saved TorchScript model working as expected in a basic test.")
+            print("Users should perform further validation as appropriate.")
+        else:
+            model_error = (
+                "Saved Torchscript model is not performing as expected.\n"
+                "Consider using scripting if you used tracing, or investigate further."
+            )
+            raise RuntimeError(model_error)
+
+    # Check that the model file is created
+    if not os.path.exists(os.path.join(filepath, saved_ts_filename)):
+        torchscript_file_error = (
+            f"Saved TorchScript file {os.path.join(filepath, saved_ts_filename)} "
+            "cannot be found."
+        )
+        raise FileNotFoundError(torchscript_file_error)

--- a/simplenet_model/simplenet.py
+++ b/simplenet_model/simplenet.py
@@ -1,0 +1,58 @@
+"""Module defining a simple PyTorch 'Net' for coupling to Fortran."""
+
+import torch
+from torch import nn
+
+
+class SimpleNet(nn.Module):
+    """PyTorch module multiplying an input vector by 2."""
+
+    def __init__(
+        self,
+    ) -> None:
+        """
+        Initialize the SimpleNet model.
+
+        Consists of a single Linear layer with weights predefined to
+        multiply the input by 2.
+        """
+        super().__init__()
+        self._fwd_seq = nn.Sequential(
+            nn.Linear(5, 5, bias=False),
+        )
+        with torch.no_grad():
+            self._fwd_seq[0].weight = nn.Parameter(2.0 * torch.eye(5))
+
+    def forward(self, batch: torch.Tensor) -> torch.Tensor:
+        """
+        Pass ``batch`` through the model.
+
+        Parameters
+        ----------
+        batch : torch.Tensor
+            A mini-batch of input vectors of length 5.
+
+        Returns
+        -------
+        torch.Tensor
+            batch scaled by 2.
+
+        """
+        return self._fwd_seq(batch)
+
+
+if __name__ == "__main__":
+    model = SimpleNet()
+    model.eval()
+
+    input_tensor = torch.Tensor([0.0, 1.0, 2.0, 3.0, 4.0])
+    with torch.no_grad():
+        output_tensor = model(input_tensor)
+
+    print(output_tensor)
+    if not torch.allclose(output_tensor, 2 * input_tensor):
+        result_error = (
+            f"result:\n{output_tensor}\ndoes not match expected value:\n"
+            f"{2 * input_tensor}"
+        )
+        raise ValueError(result_error)


### PR DESCRIPTION
This PR sets up a like-for-like comparison of our "hello world" SimpleNet case between FTorch and SmartSim. It is **NOT** intended for benchmarking, just for comparing the two approaches.

## WIP on SmartSim setup

The `simplenet_fortran_smartsim.f90` file
1. creates an input array and prints it
2. writes the input array to the database
3. reads the output array from the database and prints it

The `simplenet_python_smartsim.py` script
1. sets up the SmartRedis client and database
2. sets the `simplenet_fortran_smartsim` executable running
3. gets the input array from the database and prints it
4. applies the SimpleNet model and prints the result
5. writes the output array to the database

This is working up to the point of the output array being read from the database in Fortran. In my local setup, it's complaining that the value is unset and giving garbage. I tried adding a `call sleep(10)` as a hack but this didn't help.

I'm probably missing something from https://www.craylabs.org/docs/tutorials/getting_started/getting_started.html.

## Installation notes

<details>

When installing SmartRedis, I followed the recommendation in the HPC Days tutorial to just use `make lib-with-fortran` rather than the CMake process, which is apparently more difficult.

</details>